### PR TITLE
지도 블럭 생성, 수정, 삭제

### DIFF
--- a/api/auth-v1/src/main/java/kr/joberchip/auth/v1/security/JwtAuthenticationFilter.java
+++ b/api/auth-v1/src/main/java/kr/joberchip/auth/v1/security/JwtAuthenticationFilter.java
@@ -39,6 +39,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         try {
             DecodedJWT decodedJWT = JwtTokenProvider.verify(jwt);
             Long userId = decodedJWT.getClaim("userId").asLong();
+            String username = decodedJWT.getClaim("username").asString();
             String userRoles = decodedJWT.getClaim("userRoles").asString();
 
             User user = User.builder().userId(userId).userRoles(userRoles).build();

--- a/api/auth-v1/src/main/java/kr/joberchip/auth/v1/security/JwtTokenProvider.java
+++ b/api/auth-v1/src/main/java/kr/joberchip/auth/v1/security/JwtTokenProvider.java
@@ -21,6 +21,7 @@ public class JwtTokenProvider {
         String jwt = JWT.create()
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXP))
                 .withClaim("userId", user.getUserId())
+                .withClaim("username", user.getUsername())
                 .withClaim("userRoles", user.getUserRoles())
                 .sign(Algorithm.HMAC512(SECRET));
         return TOKEN_PREFIX + jwt;

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/ErrorMessage.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/ErrorMessage.java
@@ -9,4 +9,7 @@ public class ErrorMessage {
   // 인증 - API 접근
   public static final String UN_AUTHORIZED = "인증 되지 않은 접근";
   public static final String FORBIDDEN = "접근 거부";
+
+  // @Valid
+  public static final String NOT_EMPTY = "비어있을 수 없습니다.";
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -14,14 +14,20 @@ import java.util.UUID;
 
 @Slf4j
 @RestController
-@RequestMapping("/v1/page/{pageId}/mapBlock")
+//@RequestMapping("/v1/page/{pageId}/mapBlock")
 @RequiredArgsConstructor
 public class MapBlockController {
 
     private final MapBlockService mapBlockService;
 
+//    @PostMapping("/")
+//    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
+//        mapBlockService.createMapBlock(newMapBlock);
+//        return ResponseEntity.ok().body(ApiResponse.success());
+//    }
+
     @PostMapping("/")
-    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
+    public ResponseEntity<?> createMapBlock(@RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
         mapBlockService.createMapBlock(newMapBlock);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -32,4 +32,16 @@ public class MapBlockController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
+//    @PutMapping("/{blockId}")
+//    public ResponseEntity<?> modifyMapBlock(@PathVariable UUID pageId, @PathVariable UUID blockId, @RequestBody @Valid CreateMapBlock modifiedMapBlock, Errors errors) {
+//        mapBlockService.modifyMapBlock(blockId, modifiedMapBlock);
+//        return ResponseEntity.ok().body(ApiResponse.success());
+//    }
+
+    @PutMapping("/{blockId}")
+    public ResponseEntity<?> modifyMapBlock(@PathVariable UUID blockId, @RequestBody @Valid CreateMapBlock modifiedMapBlock, Errors errors) {
+        mapBlockService.modifyMapBlock(blockId, modifiedMapBlock);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -44,4 +44,16 @@ public class MapBlockController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
+//    @DeleteMapping("/{blockId}")
+//    public ResponseEntity<?> deleteMapBlock(@PathVariable UUID pageId, @PathVariable UUID blockId) {
+//        mapBlockService.deleteMapBlock(blockId);
+//        return ResponseEntity.ok().body(ApiResponse.success());
+//    }
+
+    @DeleteMapping("/{blockId}")
+    public ResponseEntity<?> deleteMapBlock(@PathVariable UUID blockId) {
+        mapBlockService.deleteMapBlock(blockId);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -6,8 +6,10 @@ import kr.joberchip.server.v1.share.block.service.MapBlockService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.UUID;
 
 @Slf4j
@@ -19,7 +21,7 @@ public class MapBlockController {
     private final MapBlockService mapBlockService;
 
     @PostMapping("/")
-    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, CreateMapBlock newMapBlock) {
+    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
         mapBlockService.createMapBlock(newMapBlock);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -1,0 +1,27 @@
+package kr.joberchip.server.v1.share.block.controller;
+
+import kr.joberchip.server.v1._utils.ApiResponse;
+import kr.joberchip.server.v1.share.block.dto.create.CreateMapBlock;
+import kr.joberchip.server.v1.share.block.service.MapBlockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/page/{pageId}/mapBlock")
+@RequiredArgsConstructor
+public class MapBlockController {
+
+    private final MapBlockService mapBlockService;
+
+    @PostMapping("/")
+    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, CreateMapBlock newMapBlock) {
+        mapBlockService.createMapBlock(newMapBlock);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
+}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
@@ -1,0 +1,12 @@
+package kr.joberchip.server.v1.share.block.dto.create;
+
+import lombok.Getter;
+
+@Getter
+public class CreateMapBlock {
+
+    public String address;
+    public Double latitude;
+    public Double longitude;
+
+}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
@@ -1,13 +1,19 @@
 package kr.joberchip.server.v1.share.block.dto.create;
 
 import kr.joberchip.core.share.block.MapBlock;
+import kr.joberchip.server.v1._errors.ErrorMessage;
 import lombok.Getter;
+
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 public class CreateMapBlock {
 
+    @NotEmpty(message = ErrorMessage.NOT_EMPTY)
     public String address;
+    @NotEmpty(message = ErrorMessage.NOT_EMPTY)
     public Double latitude;
+    @NotEmpty(message = ErrorMessage.NOT_EMPTY)
     public Double longitude;
 
     public MapBlock toEntity() {

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
@@ -4,17 +4,17 @@ import kr.joberchip.core.share.block.MapBlock;
 import kr.joberchip.server.v1._errors.ErrorMessage;
 import lombok.Getter;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @Getter
 public class CreateMapBlock {
 
-    @NotEmpty(message = ErrorMessage.NOT_EMPTY)
-    public String address;
-    @NotEmpty(message = ErrorMessage.NOT_EMPTY)
-    public Double latitude;
-    @NotEmpty(message = ErrorMessage.NOT_EMPTY)
-    public Double longitude;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private String address;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private Double latitude;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private Double longitude;
 
     public MapBlock toEntity() {
         return MapBlock.builder()

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/dto/create/CreateMapBlock.java
@@ -1,5 +1,6 @@
 package kr.joberchip.server.v1.share.block.dto.create;
 
+import kr.joberchip.core.share.block.MapBlock;
 import lombok.Getter;
 
 @Getter
@@ -8,5 +9,13 @@ public class CreateMapBlock {
     public String address;
     public Double latitude;
     public Double longitude;
+
+    public MapBlock toEntity() {
+        return MapBlock.builder()
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+    }
 
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
@@ -1,0 +1,8 @@
+package kr.joberchip.server.v1.share.block.repository;
+
+import kr.joberchip.core.share.block.ImageBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MapBlockRepository extends JpaRepository<ImageBlock, UUID> {}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
@@ -2,7 +2,23 @@ package kr.joberchip.server.v1.share.block.repository;
 
 import kr.joberchip.core.share.block.MapBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
-public interface MapBlockRepository extends JpaRepository<MapBlock, UUID> {}
+public interface MapBlockRepository extends JpaRepository<MapBlock, UUID> {
+
+    @Modifying
+    @Query(value =
+            "UPDATE MapBlock " +
+            "SET address = :newAddress, latitude = :newLatitude, longitude = :newLongitude " +
+            "WHERE objectId = :id")
+    void updateById(
+            @Param("newAddress") String newAddress,
+            @Param("newLatitude") Double newLatitude,
+            @Param("newLongitude") Double newLongitude,
+            @Param("id") UUID id);
+
+}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
@@ -1,8 +1,8 @@
 package kr.joberchip.server.v1.share.block.repository;
 
-import kr.joberchip.core.share.block.ImageBlock;
+import kr.joberchip.core.share.block.MapBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface MapBlockRepository extends JpaRepository<ImageBlock, UUID> {}
+public interface MapBlockRepository extends JpaRepository<MapBlock, UUID> {}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -1,0 +1,22 @@
+package kr.joberchip.server.v1.share.block.service;
+
+import kr.joberchip.server.v1.share.block.dto.create.CreateMapBlock;
+import kr.joberchip.server.v1.share.block.repository.MapBlockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MapBlockService {
+
+    private final MapBlockRepository mapBlockRepository;
+
+    @Transactional
+    public void createMapBlock(CreateMapBlock newMapBlock) {
+        mapBlockRepository.save(newMapBlock.toEntity());
+    }
+
+}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -31,4 +31,9 @@ public class MapBlockService {
                 modifiedMapBlock.getLongitude(),
                 blockId);
     }
+
+    @Transactional
+    public void deleteMapBlock(UUID blockId) {
+        mapBlockRepository.deleteById(blockId);
+    }
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -1,11 +1,14 @@
 package kr.joberchip.server.v1.share.block.service;
 
+import kr.joberchip.core.share.block.MapBlock;
 import kr.joberchip.server.v1.share.block.dto.create.CreateMapBlock;
 import kr.joberchip.server.v1.share.block.repository.MapBlockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -16,7 +19,16 @@ public class MapBlockService {
 
     @Transactional
     public void createMapBlock(CreateMapBlock newMapBlock) {
-        mapBlockRepository.save(newMapBlock.toEntity());
+        MapBlock mapBlock = mapBlockRepository.save(newMapBlock.toEntity());
+        System.out.println("mapBlock.getMapBlockId() = " + mapBlock.getMapBlockId());
     }
 
+    @Transactional
+    public void modifyMapBlock(UUID blockId, CreateMapBlock modifiedMapBlock) {
+        mapBlockRepository.updateById(
+                modifiedMapBlock.getAddress(),
+                modifiedMapBlock.getLatitude(),
+                modifiedMapBlock.getLongitude(),
+                blockId);
+    }
 }

--- a/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
+++ b/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
@@ -1,10 +1,7 @@
 package kr.joberchip.core.share.block;
 
 import kr.joberchip.core.share.BaseObject;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,6 +12,7 @@ import java.util.UUID;
 @Table(name = "map_block_tb")
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class MapBlock extends BaseObject {
 
   @Column(name = "address")

--- a/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
+++ b/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
@@ -1,0 +1,35 @@
+package kr.joberchip.core.share.block;
+
+import kr.joberchip.core.share.BaseObject;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "map_block_tb")
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MapBlock extends BaseObject {
+
+  @Column(name = "address")
+  @Getter
+  private String address;
+
+  @Column(name = "latitude")
+  @Getter
+  private Double latitude;
+
+  @Column(name = "longitude")
+  @Getter
+  private Double longitude;
+
+  public UUID getMapBlockId() {
+    return this.objectId;
+  }
+}


### PR DESCRIPTION
resolve #51 

**지도 블럭 생성, 수정, 삭제**

1. 지도블럭 엔티티(테이블) 생성
 - String address
 - Double latitude
 - Double longitude
2. pageId를 파라미터로 받지 않고 테스트할 수 있도록 본 메서드 주석처리, 테스트용 메서드 따로 구현
3. 지도 블록 생성, 수정 시 DTO가 동일 > CreateMapBlock DTO를 같이 사용중

parent_object_id 매핑 필요