### PR TITLE
지도블럭 / 생성, 수정, 삭제 기능 보완

### DIFF
--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/ErrorMessage.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/ErrorMessage.java
@@ -12,4 +12,6 @@ public class ErrorMessage {
 
   // @Valid
   public static final String NOT_EMPTY = "비어있을 수 없습니다.";
+
+  public static final String ENTITY_NOT_FOUND = "해당 페이지를 찾을 수 없습니다.";
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/GlobalExceptionHandler.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/GlobalExceptionHandler.java
@@ -1,7 +1,11 @@
 package kr.joberchip.server.v1._errors;
 
 import kr.joberchip.server.v1._errors.exceptions.ApiServerException;
+import kr.joberchip.server.v1._errors.exceptions.filter.Exception400;
+import kr.joberchip.server.v1._errors.exceptions.filter.Exception401;
+import kr.joberchip.server.v1._errors.exceptions.filter.Exception403;
 import kr.joberchip.server.v1._utils.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,4 +16,27 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiResponse.Result<Object>> globalException(ApiServerException ase) {
     return new ResponseEntity<>(ase.body(), ase.status());
   }
+
+  @ExceptionHandler(Exception400.class)
+  public ResponseEntity<ApiResponse.Result<Object>> badRequest(Exception400 e) {
+    return new ResponseEntity<>(e.body(), e.status());
+  }
+
+  @ExceptionHandler(Exception401.class)
+  public ResponseEntity<ApiResponse.Result<Object>> unAuthorized(Exception401 e) {
+    return new ResponseEntity<>(e.body(), e.status());
+  }
+
+  @ExceptionHandler(Exception403.class)
+  public ResponseEntity<ApiResponse.Result<Object>> forbidden(Exception403 e) {
+    return new ResponseEntity<>(e.body(), e.status());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiResponse.Result<Object>> unknownServerError(Exception e) {
+    ApiResponse.Result<Object> apiResult =
+            ApiResponse.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/exceptions/filter/Exception400.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/_errors/exceptions/filter/Exception400.java
@@ -1,0 +1,31 @@
+package kr.joberchip.server.v1._errors.exceptions.filter;
+
+import kr.joberchip.server.v1._utils.ApiResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/** Valid 어노테이션을 통한 유효성 검사 실패, 잘못된 파라미터 요청에 대한 Exception */
+@Getter
+public class Exception400 extends RuntimeException {
+
+  private final String key;
+  private final String value;
+
+  public Exception400(String key, String value) {
+    super(key + " : " + value);
+    this.key = key;
+    this.value = value;
+  }
+
+  public Exception400(String key) {
+    this(key, "");
+  }
+
+  public ApiResponse.Result<Object> body() {
+    return ApiResponse.error(getMessage(), status());
+  }
+
+  public HttpStatus status() {
+    return HttpStatus.BAD_REQUEST;
+  }
+}

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -5,7 +5,6 @@ import kr.joberchip.server.v1.share.block.dto.create.CreateMapBlock;
 import kr.joberchip.server.v1.share.block.service.MapBlockService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,27 +20,27 @@ public class MapBlockController {
     private final MapBlockService mapBlockService;
 
     @PostMapping("/{pageId}/mapBlock")
-    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
+    public ApiResponse.Result<Object> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
         mapBlockService.createMapBlock(pageId, newMapBlock);
-        return ResponseEntity.ok().body(ApiResponse.success());
+        return ApiResponse.success();
     }
 
     @PutMapping("/mapBlock/{blockId}")
-    public ResponseEntity<?> modifyMapBlock(@PathVariable UUID blockId, @RequestBody @Valid CreateMapBlock modifiedMapBlock, Errors errors) {
+    public ApiResponse.Result<Object> modifyMapBlock(@PathVariable UUID blockId, @RequestBody @Valid CreateMapBlock modifiedMapBlock, Errors errors) {
         mapBlockService.modifyMapBlock(blockId, modifiedMapBlock);
-        return ResponseEntity.ok().body(ApiResponse.success());
+        return ApiResponse.success();
     }
 
     @GetMapping("/mapBlock/{blockId}")
-    public ResponseEntity<?> changeVisible(@PathVariable UUID blockId) {
+    public ApiResponse.Result<Object> changeVisible(@PathVariable UUID blockId) {
         mapBlockService.changeVisible(blockId);
-        return ResponseEntity.ok().body(ApiResponse.success());
+        return ApiResponse.success();
     }
 
     @DeleteMapping("/mapBlock/{blockId}")
-    public ResponseEntity<?> deleteMapBlock(@PathVariable UUID blockId) {
+    public ApiResponse.Result<Object> deleteMapBlock(@PathVariable UUID blockId) {
         mapBlockService.deleteMapBlock(blockId);
-        return ResponseEntity.ok().body(ApiResponse.success());
+        return ApiResponse.success();
     }
 
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -14,43 +14,25 @@ import java.util.UUID;
 
 @Slf4j
 @RestController
-//@RequestMapping("/v1/page/{pageId}/mapBlock")
+@RequestMapping("/v1/page")
 @RequiredArgsConstructor
 public class MapBlockController {
 
     private final MapBlockService mapBlockService;
 
-//    @PostMapping("/")
-//    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
-//        mapBlockService.createMapBlock(newMapBlock);
-//        return ResponseEntity.ok().body(ApiResponse.success());
-//    }
-
-    @PostMapping("/")
-    public ResponseEntity<?> createMapBlock(@RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
-        mapBlockService.createMapBlock(newMapBlock);
+    @PostMapping("/{pageId}/mapBlock")
+    public ResponseEntity<?> createMapBlock(@PathVariable UUID pageId, @RequestBody @Valid CreateMapBlock newMapBlock, Errors errors) {
+        mapBlockService.createMapBlock(pageId, newMapBlock);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-//    @PutMapping("/{blockId}")
-//    public ResponseEntity<?> modifyMapBlock(@PathVariable UUID pageId, @PathVariable UUID blockId, @RequestBody @Valid CreateMapBlock modifiedMapBlock, Errors errors) {
-//        mapBlockService.modifyMapBlock(blockId, modifiedMapBlock);
-//        return ResponseEntity.ok().body(ApiResponse.success());
-//    }
-
-    @PutMapping("/{blockId}")
+    @PutMapping("/mapBlock/{blockId}")
     public ResponseEntity<?> modifyMapBlock(@PathVariable UUID blockId, @RequestBody @Valid CreateMapBlock modifiedMapBlock, Errors errors) {
         mapBlockService.modifyMapBlock(blockId, modifiedMapBlock);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-//    @DeleteMapping("/{blockId}")
-//    public ResponseEntity<?> deleteMapBlock(@PathVariable UUID pageId, @PathVariable UUID blockId) {
-//        mapBlockService.deleteMapBlock(blockId);
-//        return ResponseEntity.ok().body(ApiResponse.success());
-//    }
-
-    @DeleteMapping("/{blockId}")
+    @DeleteMapping("/mapBlock/{blockId}")
     public ResponseEntity<?> deleteMapBlock(@PathVariable UUID blockId) {
         mapBlockService.deleteMapBlock(blockId);
         return ResponseEntity.ok().body(ApiResponse.success());

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/MapBlockController.java
@@ -32,6 +32,12 @@ public class MapBlockController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
+    @GetMapping("/mapBlock/{blockId}")
+    public ResponseEntity<?> changeVisible(@PathVariable UUID blockId) {
+        mapBlockService.changeVisible(blockId);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
     @DeleteMapping("/mapBlock/{blockId}")
     public ResponseEntity<?> deleteMapBlock(@PathVariable UUID blockId) {
         mapBlockService.deleteMapBlock(blockId);

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/dto/CreateMapBlock.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/dto/CreateMapBlock.java
@@ -24,12 +24,15 @@ public class CreateMapBlock {
     @NotNull(message = ErrorMessage.NOT_EMPTY)
     private Integer width;
 
-    public MapBlock toEntity() {
-        return MapBlock.builder()
-            .address(address)
-            .latitude(latitude)
-            .longitude(longitude)
-            .build();
+    public MapBlock setEntity(MapBlock mapBlock) {
+        mapBlock.setAddress(this.getAddress());
+        mapBlock.setLatitude(this.getLatitude());
+        mapBlock.setLongitude(this.getLongitude());
+        mapBlock.setX(this.getX());
+        mapBlock.setY(this.getY());
+        mapBlock.setHeight(this.getHeight());
+        mapBlock.setWidth(this.getWidth());
+        return mapBlock;
     }
 
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/dto/CreateMapBlock.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/controller/dto/CreateMapBlock.java
@@ -15,13 +15,21 @@ public class CreateMapBlock {
     private Double latitude;
     @NotNull(message = ErrorMessage.NOT_EMPTY)
     private Double longitude;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private Integer x;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private Integer y;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private Integer height;
+    @NotNull(message = ErrorMessage.NOT_EMPTY)
+    private Integer width;
 
     public MapBlock toEntity() {
         return MapBlock.builder()
-                .address(address)
-                .latitude(latitude)
-                .longitude(longitude)
-                .build();
+            .address(address)
+            .latitude(latitude)
+            .longitude(longitude)
+            .build();
     }
 
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/repository/MapBlockRepository.java
@@ -13,12 +13,17 @@ public interface MapBlockRepository extends JpaRepository<MapBlock, UUID> {
     @Modifying
     @Query(value =
             "UPDATE MapBlock " +
-            "SET address = :newAddress, latitude = :newLatitude, longitude = :newLongitude " +
+            "SET address = :newAddress, latitude = :newLatitude, longitude = :newLongitude, " +
+                    "x = :x, y = :y, height = :height, width = :width " +
             "WHERE objectId = :id")
-    void updateById(
+    void updateAllById(
             @Param("newAddress") String newAddress,
             @Param("newLatitude") Double newLatitude,
             @Param("newLongitude") Double newLongitude,
+            @Param("x") Integer x,
+            @Param("y") Integer y,
+            @Param("height") Integer height,
+            @Param("width") Integer width,
             @Param("id") UUID id);
 
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -2,6 +2,7 @@ package kr.joberchip.server.v1.share.block.service;
 
 import kr.joberchip.core.share.block.MapBlock;
 import kr.joberchip.core.share.page.SharePage;
+import kr.joberchip.server.v1._errors.ErrorMessage;
 import kr.joberchip.server.v1.share.block.dto.create.CreateMapBlock;
 import kr.joberchip.server.v1.share.block.repository.MapBlockRepository;
 import kr.joberchip.server.v1.share.page.repository.SharePageRepository;
@@ -25,7 +26,10 @@ public class MapBlockService {
     public void createMapBlock(UUID pageId, CreateMapBlock newMapBlock) {
         // pageId를 조회해 해당 페이지가 존재하는지 확인
         SharePage parentPage =
-                sharePageRepository.findById(pageId).orElseThrow(EntityNotFoundException::new);
+                sharePageRepository.findById(pageId).orElseThrow(() -> {
+                    log.error("존재하지 않는 pageID - pageId: {}", pageId);
+                    throw new EntityNotFoundException(ErrorMessage.ENTITY_NOT_FOUND);
+                });
 
         // pageID가 존재한다면 mapBlock의 내용을 Entity로 변환, 위치정보 설정
         MapBlock mapBlock = newMapBlock.toEntity();
@@ -65,6 +69,9 @@ public class MapBlockService {
     }
 
     private void isBlock(UUID blockId) {
-        mapBlockRepository.findById(blockId).orElseThrow(EntityNotFoundException::new);
+        mapBlockRepository.findById(blockId).orElseThrow(() -> {
+            log.error("존재하지 않는 blockId - blockId: {}", blockId);
+            throw new EntityNotFoundException(ErrorMessage.ENTITY_NOT_FOUND);
+        });
     }
 }

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -40,6 +40,11 @@ public class MapBlockService {
     }
 
     @Transactional
+    public void changeVisible(UUID blockId) {
+        isBlock(blockId).changeVisible();
+    }
+
+    @Transactional
     public void deleteMapBlock(UUID blockId) {
         isBlock(blockId);
         mapBlockRepository.deleteById(blockId);

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -1,13 +1,16 @@
 package kr.joberchip.server.v1.share.block.service;
 
 import kr.joberchip.core.share.block.MapBlock;
+import kr.joberchip.core.share.page.SharePage;
 import kr.joberchip.server.v1.share.block.dto.create.CreateMapBlock;
 import kr.joberchip.server.v1.share.block.repository.MapBlockRepository;
+import kr.joberchip.server.v1.share.page.repository.SharePageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.UUID;
 
 @Slf4j
@@ -16,19 +19,41 @@ import java.util.UUID;
 public class MapBlockService {
 
     private final MapBlockRepository mapBlockRepository;
+    private final SharePageRepository sharePageRepository;
 
     @Transactional
-    public void createMapBlock(CreateMapBlock newMapBlock) {
-        MapBlock mapBlock = mapBlockRepository.save(newMapBlock.toEntity());
-        System.out.println("mapBlock.getMapBlockId() = " + mapBlock.getMapBlockId());
+    public void createMapBlock(UUID pageId, CreateMapBlock newMapBlock) {
+        // pageId를 조회해 해당 페이지가 존재하는지 확인
+        SharePage parentPage =
+                sharePageRepository.findById(pageId).orElseThrow(EntityNotFoundException::new);
+
+        // pageID가 존재한다면 mapBlock의 내용을 Entity로 변환, 위치정보 설정
+        MapBlock mapBlock = newMapBlock.toEntity();
+        mapBlock.setX(newMapBlock.getX());
+        mapBlock.setY(newMapBlock.getY());
+        mapBlock.setHeight(newMapBlock.getHeight());
+        mapBlock.setWidth(newMapBlock.getWidth());
+
+        // 생성된 mapBlock을 mapBlockRepository에 save
+        MapBlock savedmapBlock = mapBlockRepository.save(mapBlock);
+
+        // Entity로 저장된 mapBlock의 parentPage값 참조
+        // 해당 페이지의 Set<MapBlock>에 add
+        parentPage.addMapBlock(savedmapBlock);
+
+        log.info("UUID of NEW MAP BLOCK: " + savedmapBlock.getMapBlockId());
     }
 
     @Transactional
     public void modifyMapBlock(UUID blockId, CreateMapBlock modifiedMapBlock) {
-        mapBlockRepository.updateById(
+        mapBlockRepository.updateAllById(
                 modifiedMapBlock.getAddress(),
                 modifiedMapBlock.getLatitude(),
                 modifiedMapBlock.getLongitude(),
+                modifiedMapBlock.getX(),
+                modifiedMapBlock.getY(),
+                modifiedMapBlock.getHeight(),
+                modifiedMapBlock.getWidth(),
                 blockId);
     }
 

--- a/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
+++ b/api/server-v1/src/main/java/kr/joberchip/server/v1/share/block/service/MapBlockService.java
@@ -46,6 +46,7 @@ public class MapBlockService {
 
     @Transactional
     public void modifyMapBlock(UUID blockId, CreateMapBlock modifiedMapBlock) {
+        isBlock(blockId);
         mapBlockRepository.updateAllById(
                 modifiedMapBlock.getAddress(),
                 modifiedMapBlock.getLatitude(),
@@ -59,6 +60,11 @@ public class MapBlockService {
 
     @Transactional
     public void deleteMapBlock(UUID blockId) {
+        isBlock(blockId);
         mapBlockRepository.deleteById(blockId);
+    }
+
+    private void isBlock(UUID blockId) {
+        mapBlockRepository.findById(blockId).orElseThrow(EntityNotFoundException::new);
     }
 }

--- a/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
+++ b/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
@@ -34,4 +34,7 @@ public class MapBlock extends BaseObject {
     return this.objectId;
   }
 
+  public void changeVisible() {
+    this.visible = !this.visible;
+  }
 }

--- a/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
+++ b/libs/core/src/main/java/kr/joberchip/core/share/block/MapBlock.java
@@ -17,17 +17,21 @@ public class MapBlock extends BaseObject {
 
   @Column(name = "address")
   @Getter
+  @Setter
   private String address;
 
   @Column(name = "latitude")
   @Getter
+  @Setter
   private Double latitude;
 
   @Column(name = "longitude")
   @Getter
+  @Setter
   private Double longitude;
 
   public UUID getMapBlockId() {
     return this.objectId;
   }
+
 }

--- a/libs/core/src/main/java/kr/joberchip/core/share/page/SharePage.java
+++ b/libs/core/src/main/java/kr/joberchip/core/share/page/SharePage.java
@@ -42,6 +42,9 @@ public class SharePage extends BaseObject {
   @OneToMany(mappedBy = "parentObjectId", cascade = CascadeType.ALL)
   private Set<VideoBlock> videoBlocks = new LinkedHashSet<>();
 
+  @OneToMany(mappedBy = "parentObjectId", cascade = CascadeType.ALL)
+  private Set<MapBlock> mapBlocks = new LinkedHashSet<>();
+
   @OneToMany(mappedBy = "sharePage")
   private Set<PageHashtag> hashtags = new LinkedHashSet<>();
 
@@ -92,6 +95,11 @@ public class SharePage extends BaseObject {
   public void addVideoBlock(VideoBlock videoBlock) {
     videoBlock.setParentObjectId(this.getPageId());
     this.getVideoBlocks().add(videoBlock);
+  }
+
+  public void addMapBlock(MapBlock mapBlock) {
+    mapBlock.setParentObjectId(this.getPageId());
+    this.getMapBlocks().add(mapBlock);
   }
 
   public void addChildPage(SharePage sharePage) {


### PR DESCRIPTION
resolve #56 

**지도블럭 / 생성, 수정, 삭제 기능 보완**

1. 지도블럭 생성
 - pageID 조회
 - 블럭 엔티티 생성
 - 위치정보 저장
 - repository에 객체 저장
2. 지도블럭 수정
 - @PathVariable UUID pageId 삭제
 - blockId 조회
 - 블럭 위치정보 수정 반영
3. 지도블럭 삭제
 - @PathVariable UUID pageId 삭제
 - blockId 조회
 4. 기타 예외처리

**09/28 추가**
MapBlockService 메서드 일부 변경
MapBlock 의 visible 수정하는 API 별도 생성